### PR TITLE
progress: shorten bar  to prevent newlines on some terminals

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -64,7 +64,7 @@ void apk_print_progress(size_t done, size_t total)
 	if (!(apk_flags & APK_PROGRESS))
 		return;
 
-	bar_width = apk_get_screen_width() - 7;
+	bar_width = apk_get_screen_width() - 8;
 	if (total > 0) {
 		bar = muldiv(bar_width, done, total);
 		percent = muldiv(100, done, total);


### PR DESCRIPTION
On some (probably buggy) terminals, printing up to the rightmost column
may end up with the terminal issueing a newline (probably due to putting
the cursor at the next char -> new line).

Some other progress bars avoid it by not reaching the rightmost column.

Shorten the bar width from term-width - 7 to -8 (the 7 are "xxx% []").