### PR TITLE
Fix a small syntax error

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -350,7 +350,11 @@ all_done:
 
 	if (!db->performing_self_upgrade) {
 		if (errors)
-			snprintf(buf, sizeof(buf), "%d errors;", errors);
+			if (errors != 1)
+				snprintf(buf, sizeof(buf), "%d errors;", errors);
+			else
+				snprintf(buf, sizeof(buf), "%d error;", errors);
+
 		else
 			strcpy(buf, "OK:");
 		if (apk_verbosity > 1) {


### PR DESCRIPTION
Currently if your apk contains a single error, it prints "errors"
instead of "error". For example:

 $ sudo apk upgrade
 1 errors; 417 MiB in 144 packages

This patch just print a singular or plural "errors" depending on the
number of errors.