### PR TITLE
Clang fixes

### DIFF
--- a/Make.rules
+++ b/Make.rules
@@ -174,7 +174,7 @@ if_changed_rule = $(if $(strip $(any-prereq) $(arg-check) ),                 \
 #####
 # Handle options to gcc.
 
-c_flags		= -Wp,-MD,$(depfile),-MT,$@ $(CPPFLAGS) \
+c_flags		= -Wp,-MD,$(depfile) -Wp,-MT,$@ $(CPPFLAGS) \
 		  $(CFLAGS_ALL) $(CFLAGS_EXTRA) $(CFLAGS_$(notdir $@))
 ld_flags	= $(LDFLAGS_ALL) $(LDFLAGS_EXTRA) $(LDFLAGS_$(notdir $@))
 

--- a/src/archive.c
+++ b/src/archive.c
@@ -159,8 +159,9 @@ static void handle_extended_header(struct apk_file_info *fi, apk_blob_t hdr)
 		unsigned int len = apk_blob_pull_uint(&hdr, 10);
 		apk_blob_pull_char(&hdr, ' ');
 		if (!apk_blob_split(hdr, APK_BLOB_STR("="), &name, &hdr)) break;
+		if (len < hdr.ptr - start + 1) break;
 		len -= hdr.ptr - start + 1;
-		if (len < 0 || hdr.len < len) break;
+		if (hdr.len < len) break;
 		value = APK_BLOB_PTR_LEN(hdr.ptr, len);
 		hdr = APK_BLOB_PTR_LEN(hdr.ptr+len, hdr.len-len);
 		apk_blob_pull_char(&hdr, '\n');

--- a/src/archive.c
+++ b/src/archive.c
@@ -160,7 +160,7 @@ static void handle_extended_header(struct apk_file_info *fi, apk_blob_t hdr)
 		apk_blob_pull_char(&hdr, ' ');
 		if (!apk_blob_split(hdr, APK_BLOB_STR("="), &name, &hdr)) break;
 		len -= hdr.ptr - start + 1;
-		if (len < 0 || hdr.len < len) break;
+		if (hdr.len < len) break;
 		value = APK_BLOB_PTR_LEN(hdr.ptr, len);
 		hdr = APK_BLOB_PTR_LEN(hdr.ptr+len, hdr.len-len);
 		apk_blob_pull_char(&hdr, '\n');

--- a/src/archive.c
+++ b/src/archive.c
@@ -160,7 +160,7 @@ static void handle_extended_header(struct apk_file_info *fi, apk_blob_t hdr)
 		apk_blob_pull_char(&hdr, ' ');
 		if (!apk_blob_split(hdr, APK_BLOB_STR("="), &name, &hdr)) break;
 		len -= hdr.ptr - start + 1;
-		if (hdr.len < len) break;
+		if (len < 0 || hdr.len < len) break;
 		value = APK_BLOB_PTR_LEN(hdr.ptr, len);
 		hdr = APK_BLOB_PTR_LEN(hdr.ptr+len, hdr.len-len);
 		apk_blob_pull_char(&hdr, '\n');

--- a/src/commit.c
+++ b/src/commit.c
@@ -279,7 +279,7 @@ int apk_solver_commit_changeset(struct apk_database *db,
 			size_diff -= change->old_pkg->installed_size / 1024;
 	}
 	size_unit = 'K';
-	if (abs(size_diff) > 10000) {
+	if (labs(size_diff) > 10000) {
 		size_diff /= 1024;
 		size_unit = 'M';
 	}

--- a/src/io.c
+++ b/src/io.c
@@ -158,8 +158,6 @@ size_t apk_istream_skip(struct apk_istream *is, size_t size)
 		if (togo > sizeof(buf))
 			togo = sizeof(buf);
 		r = apk_istream_read(is, buf, togo);
-		if (r < 0)
-			return r;
 		done += r;
 		if (r != togo)
 			break;
@@ -207,15 +205,11 @@ size_t apk_istream_splice(void *stream, int fd, size_t size,
 		if (togo > bufsz)
 			togo = bufsz;
 		r = apk_istream_read(is, buf, togo);
-		if (r < 0)
-			goto err;
 		if (r == 0)
 			break;
 
 		if (mmapbase == MAP_FAILED) {
 			if (write(fd, buf, r) != r) {
-				if (r < 0)
-					r = -errno;
 				goto err;
 			}
 		} else
@@ -543,10 +537,6 @@ apk_blob_t apk_blob_from_istream(struct apk_istream *is, size_t size)
 		return APK_BLOB_NULL;
 
 	rsize = apk_istream_read(is, ptr, size);
-	if (rsize < 0) {
-		free(ptr);
-		return APK_BLOB_NULL;
-	}
 	if (rsize != size)
 		ptr = realloc(ptr, rsize);
 

--- a/src/io.c
+++ b/src/io.c
@@ -158,6 +158,8 @@ size_t apk_istream_skip(struct apk_istream *is, size_t size)
 		if (togo > sizeof(buf))
 			togo = sizeof(buf);
 		r = apk_istream_read(is, buf, togo);
+		if (r < 0)
+			return r;
 		done += r;
 		if (r != togo)
 			break;
@@ -205,11 +207,15 @@ size_t apk_istream_splice(void *stream, int fd, size_t size,
 		if (togo > bufsz)
 			togo = bufsz;
 		r = apk_istream_read(is, buf, togo);
+		if (r < 0)
+			goto err;
 		if (r == 0)
 			break;
 
 		if (mmapbase == MAP_FAILED) {
 			if (write(fd, buf, r) != r) {
+				if (r < 0)
+					r = -errno;
 				goto err;
 			}
 		} else
@@ -537,6 +543,10 @@ apk_blob_t apk_blob_from_istream(struct apk_istream *is, size_t size)
 		return APK_BLOB_NULL;
 
 	rsize = apk_istream_read(is, ptr, size);
+	if (rsize < 0) {
+		free(ptr);
+		return APK_BLOB_NULL;
+	}
 	if (rsize != size)
 		ptr = realloc(ptr, rsize);
 

--- a/src/io.c
+++ b/src/io.c
@@ -151,7 +151,8 @@ struct apk_istream *apk_istream_from_file(int atfd, const char *file)
 size_t apk_istream_skip(struct apk_istream *is, size_t size)
 {
 	unsigned char buf[2048];
-	size_t done = 0, r, togo;
+	size_t done = 0, togo;
+	ssize_t r;
 
 	while (done < size) {
 		togo = size - done;
@@ -173,7 +174,8 @@ size_t apk_istream_splice(void *stream, int fd, size_t size,
 	static void *splice_buffer = NULL;
 	struct apk_istream *is = (struct apk_istream *) stream;
 	unsigned char *buf, *mmapbase = MAP_FAILED;
-	size_t bufsz, done = 0, r, togo;
+	size_t bufsz, done = 0, togo;
+	ssize_t r;
 
 	bufsz = size;
 	if (size > 128 * 1024) {
@@ -536,7 +538,7 @@ struct apk_bstream *apk_bstream_tee(struct apk_bstream *from, int atfd, const ch
 apk_blob_t apk_blob_from_istream(struct apk_istream *is, size_t size)
 {
 	void *ptr;
-	size_t rsize;
+	ssize_t rsize;
 
 	ptr = malloc(size);
 	if (ptr == NULL)


### PR DESCRIPTION
When compiling with clang, the following errors are produced:

    src/archive.c:163:11: error: comparison of unsigned expression < 0 is always
          false [-Werror,-Wtautological-compare]
                    if (len < 0 || hdr.len < len) break;
                        ~~~ ^ ~
    src/commit.c:282:6: error: absolute value function 'abs' given an argument of
          type 'ssize_t' (aka 'long') but has parameter of type 'int' which may
          cause truncation of value [-Werror,-Wabsolute-value]
            if (abs(size_diff) > 10000) {
                ^
    src/commit.c:282:6: note: use function 'labs' instead
            if (abs(size_diff) > 10000) {
                ^~~
                labs
    src/io.c:161:9: error: comparison of unsigned expression < 0 is always false
          [-Werror,-Wtautological-compare]
                    if (r < 0)
                        ~ ^ ~
    src/io.c:210:9: error: comparison of unsigned expression < 0 is always false
          [-Werror,-Wtautological-compare]
                    if (r < 0)
                        ~ ^ ~
    src/io.c:217:11: error: comparison of unsigned expression < 0 is always false
          [-Werror,-Wtautological-compare]
                                    if (r < 0)
                                        ~ ^ ~
    src/io.c:546:12: error: comparison of unsigned expression < 0 is always false
          [-Werror,-Wtautological-compare]
            if (rsize < 0) {
                ~~~~~ ^ ~

Also the preprocessor argument syntax is not parsed by clang.

I tried to fix these errors and tested it with and without lua, it compiles fine and works.