### PR TITLE
add new flag --initramfs-diskless-boot

### DIFF
--- a/src/apk.c
+++ b/src/apk.c
@@ -217,6 +217,9 @@ static int option_parse_commit(void *ctx, struct apk_db_options *dbopts, int opt
 	case 0x113:
 		apk_flags |= APK_NO_SCRIPTS;
 		break;
+	case 0x117:
+		apk_flags |= APK_NO_COMMIT_HOOKS;
+		break;
 	default:
 		return -ENOTSUP;
 	}
@@ -228,6 +231,7 @@ static const struct apk_option options_commit[] = {
 	{ 0x102, "clean-protected",	"Do not create .apk-new files in configuration dirs" },
 	{ 0x111, "overlay-from-stdin",	"Read list of overlay files from stdin" },
 	{ 0x113, "no-scripts",		"Do not execute any scripts" },
+	{ 0x117, "no-commit-hooks",	"Skip pre/post hook scripts (but not other scripts)" },
 };
 
 const struct apk_option_group optgroup_commit = {

--- a/src/apk.c
+++ b/src/apk.c
@@ -220,6 +220,10 @@ static int option_parse_commit(void *ctx, struct apk_db_options *dbopts, int opt
 	case 0x117:
 		apk_flags |= APK_NO_COMMIT_HOOKS;
 		break;
+	case 0x118:
+		dbopts->open_flags |= APK_OPENF_CREATE;
+		apk_flags |= APK_FORCE | APK_NO_COMMIT_HOOKS;
+		break;
 	default:
 		return -ENOTSUP;
 	}
@@ -232,6 +236,8 @@ static const struct apk_option options_commit[] = {
 	{ 0x111, "overlay-from-stdin",	"Read list of overlay files from stdin" },
 	{ 0x113, "no-scripts",		"Do not execute any scripts" },
 	{ 0x117, "no-commit-hooks",	"Skip pre/post hook scripts (but not other scripts)" },
+	{ 0x118, "initramfs-diskless-boot",
+	  "Enables options for diskeless initramfs boot (e.g. skip hooks)" },
 };
 
 const struct apk_option_group optgroup_commit = {

--- a/src/apk_defines.h
+++ b/src/apk_defines.h
@@ -77,6 +77,7 @@ extern char **apk_argv;
 #define APK_OVERLAY_FROM_STDIN	0x2000
 #define APK_NO_SCRIPTS		0x4000
 #define APK_NO_CACHE		0x8000
+#define APK_NO_COMMIT_HOOKS	0x00010000
 
 /* default architecture for APK packages. */
 #if defined(__x86_64__)

--- a/src/commit.c
+++ b/src/commit.c
@@ -236,6 +236,10 @@ static int run_commit_hook(void *ctx, int dirfd, const char *file)
 		return 0;
 
 	snprintf(fn, sizeof(fn), "etc/apk/commit_hooks.d" "/%s", file);
+	if ((apk_flags & APK_NO_COMMIT_HOOKS) != 0 ) {
+		apk_message("Skipping: %s %s", fn, commit_hook_str[hook->type]);
+		return 0;
+	}
 	if (apk_verbosity >= 2) apk_message("Executing: %s %s", fn, commit_hook_str[hook->type]);
 
 	if (apk_db_run_script(db, fn, argv) < 0 && hook->type == PRE_COMMIT_HOOK)


### PR DESCRIPTION
This flag skips running hook scripts and enables other options
needed during *diskless* initramfs-boot.

This flag *must* be used during initramfs tmpfs initial install.
The reason that this new flag is needed is that the hooks will currently
always fail as musl and /bin/sh is missing at this stage on diskless.