### PR TITLE
Change hardcoded "gcc" to "cc"

### DIFF
--- a/Make.rules
+++ b/Make.rules
@@ -64,7 +64,7 @@ export FULL_VERSION RCS_FIND_IGNORE
 # Utilities and default flags for them.
 
 CROSS_COMPILE	?=
-CC		:= $(CROSS_COMPILE)gcc
+CC		:= $(CROSS_COMPILE)cc
 AR		:= $(CROSS_COMPILE)ar
 LD		:= $(CROSS_COMPILE)ld
 INSTALL		:= install


### PR DESCRIPTION
This change helps with POSIX compliance by changing the contents of Make.rules such that the default C compiler used is "cc", not "gcc". This allows the user to choose which C compiler they wish to use, rather than being forced into using gcc. 