### PR TITLE
url: return relevant error value from apk_istream_fetch

### DIFF
--- a/src/url.c
+++ b/src/url.c
@@ -110,14 +110,21 @@ static const struct apk_istream_ops fetch_istream_ops = {
 
 static struct apk_istream *apk_istream_fetch(const char *url, time_t since)
 {
-	struct apk_fetch_istream *fis;
+	struct apk_fetch_istream *fis = NULL;
 	struct url *u;
 	fetchIO *io = NULL;
-	int rc = -ENOMEM;
+	int rc = -EIO;
 
 	u = fetchParseURL(url);
+	if (!u) {
+		rc = -EAPKBADURL;
+		goto err;
+	}
 	fis = malloc(sizeof(*fis));
-	if (!fis || !u) goto err;
+	if (!fis) {
+		rc = -ENOMEM;
+		goto err;
+	}
 
 	u->last_modified = since;
 	io = fetchXGet(u, &fis->urlstat, (apk_force & APK_FORCE_REFRESH) ? "Ci" : "i");


### PR DESCRIPTION
In apk_istream_fetch, the error return value was initialized to ENOMEM.
It would be returned unchanged if the URL failed to parse:
```
$ apk --no-cache -X http: info alpine-base
fetch http:/x86_64/APKINDEX.tar.gz
WARNING: Ignoring http:/x86_64/APKINDEX.tar.gz: Out of memory
```

This change initializes it with a generic value and returns an appropriate value for an invalid URL:
```
$ apk --no-cache -X http: info alpine-base
fetch http:/x86_64/APKINDEX.tar.gz
WARNING: Ignoring http:/x86_64/APKINDEX.tar.gz: invalid URL (check your repositories file)
```