### PR TITLE
Invalidate id cache after script execution

### DIFF
--- a/src/package.c
+++ b/src/package.c
@@ -1032,6 +1032,10 @@ void apk_ipkg_run_script(struct apk_installed_package *ipkg,
 
 	if (apk_db_run_script(db, fn, argv) < 0)
 		goto err;
+
+	/* Script may have done something that changes id cache contents */
+	apk_id_cache_reset(&db->id_cache);
+
 	goto cleanup;
 
 err_log:


### PR DESCRIPTION
It's common for a pre-install script to do something like
    addgroup -S group 2>/dev/null
When apk installs files after this, it sets the owner/group based on id cache
but currently the id cache is stale and doesn't contain the new group at that
point: instead the file will be installed with gid that the build host
happened to have for that group -- on target this might mean a non-existing
group or a completely different group.

We can't know if the script really did modify id cache contents so make sure
to reset the id cache on every script execution.

---

Two caveats with this:
1. The patch is against master but all my testing was against the version in alpine 3.7.
2. I'm not really familiar with apk code: this looks right to me and consistently makes our internal package (where we noticed this) get the correct group... but reality is I'm still poking around in code I don't know.

