### PR TITLE
list: fix segmentation fault with virtual packages

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -101,9 +101,15 @@ static const struct apk_package *is_upgradable(struct apk_name *name, const stru
 
 static void print_package(const struct apk_package *pkg, const struct list_ctx *ctx)
 {
-	printf(PKG_VER_FMT " " BLOB_FMT " {" BLOB_FMT "} (" BLOB_FMT ")",
-		PKG_VER_PRINTF(pkg), BLOB_PRINTF(*pkg->arch), BLOB_PRINTF(*pkg->origin),
-		BLOB_PRINTF(*pkg->license));
+	printf(PKG_VER_FMT " " BLOB_FMT " ",
+		PKG_VER_PRINTF(pkg), BLOB_PRINTF(*pkg->arch));
+
+	if (pkg->origin != NULL)
+		printf("{" BLOB_FMT "}", BLOB_PRINTF(*pkg->origin));
+	else
+		printf("{%s}", pkg->name->name);
+
+	printf(" (" BLOB_FMT ")", BLOB_PRINTF(*pkg->license));
 
 	if (pkg->ipkg)
 		printf(" [installed]");


### PR DESCRIPTION
Virtual packages have the origin pointer set to NULL. Trying to print it
using the BLOB_PRINTF macros causes a segmentation fault.

Inspired by the `print_origin_name` function from `src/search.c` this
commit attempts to fix this by checking whether `pkg->origin` is NULL
before attempting to print it. If it is NULL the pkg name is printed
instead.

Since printing the pkg name requires a different format string this
commit splits the printf call for printing the package line into
multiple ones. The output format shouldn't have changed at all though.