### PR TITLE
Humanize size output of `apk info`

### DIFF
--- a/src/apk_print.h
+++ b/src/apk_print.h
@@ -26,6 +26,7 @@ const char *apk_error_str(int error);
 
 void apk_reset_screen_width(void);
 int apk_get_screen_width(void);
+const char *apk_get_human_size(off_t size, off_t *dest);
 
 struct apk_indent {
 	int x;

--- a/src/info.c
+++ b/src/info.c
@@ -179,12 +179,16 @@ static void info_print_license(struct apk_database *db, struct apk_package *pkg)
 
 static void info_print_size(struct apk_database *db, struct apk_package *pkg)
 {
+	off_t size;
+	const char *size_unit;
+
+	size_unit = apk_get_human_size(pkg->installed_size, &size);
 	if (apk_verbosity > 1)
-		printf("%s: %zu", pkg->name->name, pkg->installed_size);
+		printf("%s: %lld %s", pkg->name->name,
+		       (long long)size, size_unit);
 	else
-		printf(PKG_VER_FMT " installed size:\n%zu\n",
-		       PKG_VER_PRINTF(pkg),
-		       pkg->installed_size);
+		printf(PKG_VER_FMT " installed size:\n%lld %s\n",
+		       PKG_VER_PRINTF(pkg), (long long)size, size_unit);
 }
 
 static void info_print_dep_array(struct apk_database *db, struct apk_package *pkg,

--- a/src/print.c
+++ b/src/print.c
@@ -9,12 +9,14 @@
  * by the Free Software Foundation. See http://www.gnu.org/ for details.
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <malloc.h>
 #include <errno.h>
 #include <sys/ioctl.h>
+#include <sys/types.h>
 
 #include "apk_defines.h"
 #include "apk_print.h"
@@ -23,6 +25,7 @@ int apk_progress_fd;
 static int apk_screen_width = 0;
 static int apk_progress_force = 1;
 static const char *apk_progress_char = "#";
+static const char *apk_size_units[] = {"B", "KiB", "MiB", "GiB", "TiB"};
 
 void apk_reset_screen_width(void)
 {
@@ -51,6 +54,21 @@ int apk_get_screen_width(void)
 		apk_progress_char = progress_char;
 
 	return apk_screen_width;
+}
+
+const char *apk_get_human_size(off_t size, off_t *dest)
+{
+	size_t i;
+	off_t s;
+
+	assert(size >= 0);
+
+	for (i = 0, s = size; s >= 10000 &&
+	     i < ARRAY_SIZE(apk_size_units); i++)
+		s /= 1024;
+
+	if (dest) *dest = s;
+	return apk_size_units[min(i, ARRAY_SIZE(apk_size_units) - 1)];
 }
 
 void apk_print_progress(size_t done, size_t total)


### PR DESCRIPTION
This commits adds a function for receiving the closet byte unit and the
size in that unit for a given size_t. The function doesn't return a
string since dynamic memory allocation (or a static buffer) would be 
required to implement this properly.

Discussion: It might be useful to add a command line flag for enabling/disabling
this behaviour in order to retain compatibility with the previous apk
info output format. 