### PR TITLE
search: Show in "simple" help output

### DIFF
--- a/src/add.c
+++ b/src/add.c
@@ -90,7 +90,7 @@ static struct apk_package *create_virtual_package(struct apk_database *db, struc
 	time_t now = apk_time();
 	pid_t pid = getpid();
 
-	localtime_r(&now, &tm);
+	gmtime_r(&now, &tm);
 	strftime(ver, sizeof ver, "%Y%m%d.%H%M%S", &tm);
 
 	virtpkg = apk_pkg_new();

--- a/src/search.c
+++ b/src/search.c
@@ -209,6 +209,7 @@ static struct apk_applet apk_search = {
 	.help = "Search package by PATTERNs or by indexed dependencies",
 	.arguments = "PATTERN",
 	.open_flags = APK_OPENF_READ | APK_OPENF_NO_STATE,
+	.command_groups = APK_COMMAND_GROUP_QUERY,
 	.context_size = sizeof(struct search_ctx),
 	.optgroups = { &optgroup_global, &optgroup_applet },
 	.main = search_main,

--- a/test/solver.sh
+++ b/test/solver.sh
@@ -4,7 +4,6 @@ get_block() {
 	awk '/^@'$1'/{p=1;next} /^@/{p=0} p{print}'
 }
 
-export TZ=UTC
 APK_TEST="../src/apk-test"
 TEST_TO_RUN="$@"
 


### PR DESCRIPTION
Most users probably want to know about the 'search' applet.

Omission from 'apk --help' output [reported by fungalnet](https://www.reddit.com/r/AdelieLinux/comments/c8mtk9/apk_search/).