### PR TITLE
search: Show in "simple" help output

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -209,6 +209,7 @@ static struct apk_applet apk_search = {
 	.help = "Search package by PATTERNs or by indexed dependencies",
 	.arguments = "PATTERN",
 	.open_flags = APK_OPENF_READ | APK_OPENF_NO_STATE,
+	.command_groups = APK_COMMAND_GROUP_QUERY,
 	.context_size = sizeof(struct search_ctx),
 	.optgroups = { &optgroup_global, &optgroup_applet },
 	.main = search_main,


### PR DESCRIPTION
Most users probably want to know about the 'search' applet.

Omission from 'apk --help' output [reported by fungalnet](https://www.reddit.com/r/AdelieLinux/comments/c8mtk9/apk_search/).