### PR TITLE
libfetch: fix no_proxy match

### DIFF
--- a/libfetch/common.c
+++ b/libfetch/common.c
@@ -1085,7 +1085,7 @@ fetch_no_proxy_match(const char *host)
 				break;
 
 		d_len = q - p;
-		if (d_len > 0 && h_len > d_len &&
+		if (d_len > 0 && h_len >= d_len &&
 		    strncasecmp(host + h_len - d_len,
 			p, d_len) == 0) {
 			/* domain name matches */


### PR DESCRIPTION
see also:
https://github.com/freebsd/freebsd/commit/5ac7c6cc4e2462cb819184a2e2efc3cc49d4b667

Signed-off-by: luo.runbing <luo.runbing@zte.com.cn>